### PR TITLE
Remove the dev path from the image name in zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Edit the docker-compose.yml file as follows:
 version: '2'
 services:
   zookeeper:
-    image: 31z4/zookeeper
+    image: zookeeper
     restart: always
     hostname: zoo1
     ports:


### PR DESCRIPTION
We should pull from the official zookeeper image instead of the dev who created the official image.