### PR TITLE
 MODAES-6: Update Vert.x and other dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <vertx.version>3.5.4</vertx.version>
-    <rest-assured.version>3.1.0</rest-assured.version>
+    <vertx.version>3.9.0</vertx.version>
+    <rest-assured.version>4.3.0</rest-assured.version>
     <jsonpath.version>2.4.0</jsonpath.version>
-    <junit.version>4.12</junit.version>
+    <junit.version>5.5.2</junit.version>
   </properties>
 
   <repositories>
@@ -55,51 +55,74 @@
     <tag>HEAD</tag>
   </scm>
 
-  <dependencies>
 
-    <!-- logging see http://www.slf4j.org/legacy.html -->
-    <!-- we use SLF4J for our logging interface -->
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.13.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${junit.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.18</version>
-    </dependency>
-    <!-- we use log4j as our logging implementation -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.13.0</version>
+        <scope>runtime</scope>
     </dependency>
-    <!-- include slf4j bridges to proxy all logging from library deps to 
-      our logging impl -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>1.7.18</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>runtime</scope>
     </dependency>
-    <!-- we don't use JUL bridge because it requires bootstrapping in the 
-      code -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jul-to-slf4j</artifactId>
-      <version>1.7.18</version>
-      <scope>provided</scope>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
     </dependency>
-    <!-- exclude transitive logging dependencies pulled by library deps, 
-      we do that by setting the scope to 'provided' -->
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.2</version>
-      <scope>provided</scope>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
     </dependency>
-    <!-- logging config ends -->
-
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-kafka-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <version>${jsonpath.version}</version>
+    </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
@@ -113,65 +136,51 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-codegen</artifactId>
-      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
-      <artifactId>vertx-unit</artifactId>
-      <version>${vertx.version}</version>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.23.4</version>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>3.0.0</version>
-        <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web-client</artifactId>
-      <version>${vertx.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-core</artifactId>
-      <version>${vertx.version}</version>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>3.3.3</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-web</artifactId>
-      <version>${vertx.version}</version>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.0.2</version>
+      <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-kafka-client</artifactId>
-      <version>${vertx.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-      <version>${jsonpath.version}</version>
-    </dependency>
-
   </dependencies>
+
   <build>
     <resources>
       <resource>
@@ -195,7 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <id>filter-descriptor-inputs</id>
@@ -247,7 +256,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.4</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -255,7 +264,21 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>module-info.class</exclude>
+                    <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/DEPENDENCIES</exclude>
+                    <exclude>META-INF/NOTICE</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/io.netty.versions.properties</resource>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
                     <Main-Class>io.vertx.core.Launcher</Main-Class>
@@ -265,6 +288,23 @@
               </transformers>
               <artifactSet />
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <ignoreNonCompile>true</ignoreNonCompile>
+              <failOnWarning>true</failOnWarning>
             </configuration>
           </execution>
         </executions>
@@ -286,15 +326,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.1</version>
-        <configuration>
-          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader 
-            https://issues.folio.org/browse/FOLIO-1609 https://issues.apache.org/jira/browse/SUREFIRE-1588 -->
-          <useSystemClassLoader>false</useSystemClassLoader>
-        </configuration>
+        <version>3.0.0-M4</version>
       </plugin>
 
     </plugins>
   </build>
-
 </project>

--- a/src/main/java/org/folio/aes/AesLauncher.java
+++ b/src/main/java/org/folio/aes/AesLauncher.java
@@ -8,7 +8,7 @@ import io.vertx.core.VertxOptions;
 public class AesLauncher {
 
   static {
-    System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.SLF4JLogDelegateFactory");
+    System.setProperty("vertx.logger-delegate-factory-class-name", "io.vertx.core.logging.Log4j2LogDelegateFactory");
   }
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/aes/service/AesService.java
+++ b/src/main/java/org/folio/aes/service/AesService.java
@@ -6,17 +6,17 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.aes.util.AesUtils;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 
 public class AesService {
 
-  private static Logger logger = LoggerFactory.getLogger(AesService.class);
+  private static Logger logger = LogManager.getLogger();
 
   private RuleService ruleService;
   private QueueService queueService;
@@ -42,7 +42,7 @@ public class AesService {
           skip = true;
         }
       } catch (Exception e) {
-        logger.warn("Invalid Okapi token format: " + token);
+        logger.warn("Invalid Okapi token format: {}", token);
         skip = true;
       }
     }
@@ -103,7 +103,7 @@ public class AesService {
       try {
         bodyJsonObject = new JsonObject(bodyString);
       } catch (Exception e) {
-        logger.warn("Failed to convert to JSON: " + ctx.getBodyAsString());
+        logger.warn("Failed to convert to JSON: {}", ctx::getBodyAsString);
         bodyJsonObject = null;
       }
     }

--- a/src/main/java/org/folio/aes/service/KafkaService.java
+++ b/src/main/java/org/folio/aes/service/KafkaService.java
@@ -2,15 +2,16 @@ package org.folio.aes.service;
 
 import java.util.Properties;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import io.vertx.core.Vertx;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 
 public class KafkaService {
 
-  private static Logger logger = LoggerFactory.getLogger(KafkaService.class);
+  private static Logger logger = LogManager.getLogger();
 
   public KafkaProducer<String, String> createProducer(Vertx vertx, Properties config) {
     logger.debug("Creating a Kafka producer");
@@ -21,5 +22,4 @@ public class KafkaService {
     logger.debug("Creating a Kafka producer record");
     return KafkaProducerRecord.create(topic, message);
   }
-
 }

--- a/src/main/java/org/folio/aes/service/QueueServiceLogImpl.java
+++ b/src/main/java/org/folio/aes/service/QueueServiceLogImpl.java
@@ -2,8 +2,8 @@ package org.folio.aes.service;
 
 import java.util.concurrent.CompletableFuture;
 
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Just log the message.
@@ -11,12 +11,12 @@ import io.vertx.core.logging.LoggerFactory;
  */
 public class QueueServiceLogImpl implements QueueService {
 
-  private static Logger logger = LoggerFactory.getLogger(QueueServiceLogImpl.class);
+  private static Logger logger = LogManager.getLogger();
 
   @Override
   public CompletableFuture<Void> send(String topic, String msg) {
     CompletableFuture<Void> cf = new CompletableFuture<>();
-    logger.info("topic: " + topic);
+    logger.info("topic: {}", topic);
     logger.info(msg);
     cf.complete(null);
     return cf;

--- a/src/main/java/org/folio/aes/service/RuleServiceConfigImpl.java
+++ b/src/main/java/org/folio/aes/service/RuleServiceConfigImpl.java
@@ -8,14 +8,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.aes.model.RoutingRule;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.client.HttpRequest;
 import io.vertx.ext.web.client.HttpResponse;
 import io.vertx.ext.web.client.WebClient;
@@ -25,7 +25,7 @@ import io.vertx.ext.web.client.WebClient;
  */
 public class RuleServiceConfigImpl implements RuleService {
 
-  private static Logger logger = LoggerFactory.getLogger(RuleServiceConfigImpl.class);
+  private static Logger logger = LogManager.getLogger();
 
   private static final long CACHE_PERIOD = 1 * 60 * 1000L; // one minute
 
@@ -53,12 +53,12 @@ public class RuleServiceConfigImpl implements RuleService {
     if (cache != null && (System.currentTimeMillis() - cache.timestamp < CACHE_PERIOD)) {
       cf.complete(cache.rules);
     } else {
-      logger.info("Refresh routing rules for tenant " + tenant);
+      logger.info("Refresh routing rules for tenant {}", tenant);
       getFreshRules(okapiUrl, tenant, token)
         .thenAccept(rules -> {
           cachedRules.put(tenant, new CachedRoutingRules(System.currentTimeMillis(), rules));
           cf.complete(rules);
-          logger.info("Refreshed rules: " + rules);
+          logger.info("Refreshed rules: {}", rules);
         }).handle((res, ex) -> {
           if (ex != null) {
             logger.warn(ex);

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{HH:mm:ss} %-5p %-20.20C{1} %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="${sys:loglevel:-info}">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/src/test/java/org/folio/aes/AesVerticleTest.java
+++ b/src/test/java/org/folio/aes/AesVerticleTest.java
@@ -1,0 +1,77 @@
+package org.folio.aes;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.aes.test.Utils.nextFreePort;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.restassured.RestAssured;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class AesVerticleTest {
+  private static Logger log = LogManager.getLogger();
+
+  static {
+    System.setProperty("vertx.logger-delegate-factory-class-name",
+        "io.vertx.core.logging.Log4j2LogDelegateFactory");
+  }
+
+  @BeforeEach
+  @DisplayName("Deploy the verticle")
+  void setUp(Vertx vertx, VertxTestContext testContext, TestInfo testInfo) {
+    log.info("Starting: {}", testInfo.getDisplayName());
+
+    final int port = nextFreePort();
+    final JsonObject config = new JsonObject();
+    config.put("port", port);
+
+    final DeploymentOptions opts = new DeploymentOptions();
+    opts.setConfig(config);
+
+    vertx.deployVerticle(new AesVerticle(), opts, testContext.completing());
+
+    RestAssured.port = port;
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+    log.info("Verticle deployment complete");
+  }
+
+  @AfterEach
+  @DisplayName("Shutdown")
+  void tearDown(Vertx vertx, TestInfo testInfo) {
+    log.info("Finished: {}", testInfo.getDisplayName());
+  }
+
+  @Test
+  void rootApiResponds() {
+    given()
+    .when()
+      .get("/")
+    .then()
+      .statusCode(is(200))
+      .body(is("mod-aes is up running"));
+  }
+
+  @Test
+  void healthCheckResponds() {
+    given()
+    .when()
+      .get("/admin/health")
+    .then()
+      .statusCode(is(200))
+      .body(is("OK"));
+  }
+}

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.MultiMap;
@@ -136,7 +135,7 @@ public class AesServiceTest {
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
     CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
     cf.completeExceptionally(new RuntimeException("abc"));
-    when(ruleService.getRules(Mockito.any(), any(), any())).thenReturn(cf);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {

--- a/src/test/java/org/folio/aes/service/KafkaServiceTest.java
+++ b/src/test/java/org/folio/aes/service/KafkaServiceTest.java
@@ -1,32 +1,36 @@
 package org.folio.aes.service;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Properties;
 
-import static org.junit.Assert.*;
-
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.config.ConfigException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Vertx;
+import io.vertx.junit5.VertxExtension;
 
+@ExtendWith(VertxExtension.class)
 public class KafkaServiceTest {
 
   private KafkaService KafkaService = new KafkaService();
 
-  @Test(expected = ConfigException.class)
-  public void testCreateProducer() {
-    Vertx vertx = Vertx.vertx();
-    try {
-      assertNotNull(KafkaService.createProducer(vertx, new Properties()));
-    } finally {
-      vertx.close();
-    }
+  @Test
+  public void testCreateProducer(Vertx vertx) {
+    final KafkaException expectedException = assertThrows(
+        KafkaException.class,
+        () -> assertNotNull(KafkaService.createProducer(vertx, new Properties())));
+
+    assertThat(expectedException.getCause(), isA(ConfigException.class));
   }
 
   @Test
   public void testCreateProducerRecord() {
-    System.out.println(KafkaService.createProducerRecord("test", "test"));
     assertNotNull(KafkaService.createProducerRecord("test", "test"));
   }
-
 }

--- a/src/test/java/org/folio/aes/service/QueueServiceLogImplTest.java
+++ b/src/test/java/org/folio/aes/service/QueueServiceLogImplTest.java
@@ -1,10 +1,10 @@
 package org.folio.aes.service;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class QueueServiceLogImplTest {
 

--- a/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
+++ b/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
@@ -1,6 +1,7 @@
 package org.folio.aes.service;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.aes.test.Utils.nextFreePort;
 import static org.folio.aes.util.AesConstants.CONFIG_CONFIGS;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_CRITERIA;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_TARGET;
@@ -8,11 +9,8 @@ import static org.folio.aes.util.AesConstants.CONFIG_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
 
 import org.folio.aes.model.RoutingRule;
 import org.junit.jupiter.api.AfterAll;
@@ -88,30 +86,5 @@ public class RuleServiceConfigImplTest {
     }
     jo.put(CONFIG_CONFIGS, ja);
     return jo.encodePrettily();
-  }
-
-  private static int nextFreePort() {
-    int maxTries = 10000;
-    int port = ThreadLocalRandom.current().nextInt(49152, 65535);
-    while (true) {
-      if (isLocalPortFree(port)) {
-        return port;
-      } else {
-        port = ThreadLocalRandom.current().nextInt(49152, 65535);
-      }
-      maxTries--;
-      if (maxTries == 0) {
-        return 8081;
-      }
-    }
-  }
-
-  private static boolean isLocalPortFree(int port) {
-    try {
-      new ServerSocket(port).close();
-      return true;
-    } catch (IOException e) {
-      return false;
-    }
   }
 }

--- a/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
+++ b/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
@@ -1,7 +1,12 @@
 package org.folio.aes.service;
 
-import static org.folio.aes.util.AesConstants.*;
-import static org.junit.Assert.*;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.aes.util.AesConstants.CONFIG_CONFIGS;
+import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_CRITERIA;
+import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_TARGET;
+import static org.folio.aes.util.AesConstants.CONFIG_VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -10,53 +15,52 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.folio.aes.model.RoutingRule;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpServer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
 
-@RunWith(VertxUnitRunner.class)
+@ExtendWith(VertxExtension.class)
 public class RuleServiceConfigImplTest {
 
   private static int port;
-  private static Vertx vertx;
-  private static HttpServer okapi;
   private static String tenant = "tenant";
   private static String token = "token";
   private static int count = 10;
 
   private RuleService ruleService;
 
-  @BeforeClass
-  public static void setUpOnce(TestContext context) throws Exception {
-    Async async = context.async();
+  @BeforeAll
+  @DisplayName("Start HTTP server")
+  public static void setUpOnce(Vertx vertx, VertxTestContext context) throws Throwable {
     port = nextFreePort();
-    vertx = Vertx.vertx();
-    okapi = vertx.createHttpServer().requestHandler(r -> {
+    vertx.createHttpServer().requestHandler(r -> {
       r.response().end(getConfigMock());
-    }).listen(port, result -> {
-      context.assertTrue(result.succeeded());
-      async.complete();
-    });
+    }).listen(port, context.completing());
+
+    assertTrue(context.awaitCompletion(5, SECONDS));
+
+    if (context.failed()) {
+      throw context.causeOfFailure();
+    }
   }
 
-  @AfterClass
-  public static void tearDownOnce(TestContext context) throws Exception {
-    Async async = context.async();
-    okapi.close(r -> async.complete());
+  @AfterAll
+  @DisplayName("Shut down HTTP server")
+  public static void tearDownOnce(Vertx vertx, VertxTestContext context) {
+    vertx.close(context.completing());
   }
 
-  @Before
-  public void setUp() {
+  @BeforeEach
+  public void setUp(Vertx vertx) {
     ruleService = new RuleServiceConfigImpl(vertx);
   }
 

--- a/src/test/java/org/folio/aes/test/Utils.java
+++ b/src/test/java/org/folio/aes/test/Utils.java
@@ -1,0 +1,33 @@
+package org.folio.aes.test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.ThreadLocalRandom;
+
+public final class Utils {
+  private Utils() {
+    super();
+  }
+
+  public static int nextFreePort() {
+    int maxTries = 10_000;
+    do {
+      final int port = ThreadLocalRandom.current().nextInt(49152, 65535);
+      if (isLocalPortFree(port)) {
+        return port;
+      }
+      if (--maxTries == 0) {
+        return 8081;
+      }
+    } while (true);
+  }
+
+  private static boolean isLocalPortFree(int port) {
+    try {
+      new ServerSocket(port).close();
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}

--- a/src/test/java/org/folio/aes/util/AesUtilsTest.java
+++ b/src/test/java/org/folio/aes/util/AesUtilsTest.java
@@ -1,6 +1,10 @@
 package org.folio.aes.util;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -10,8 +14,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.folio.aes.util.AesUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
@@ -103,16 +106,19 @@ public class AesUtilsTest {
     assertEquals("diku", jo.getValue("tenant"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecodeOkapiTokenInvalidTokenFomrat() {
-    String token = "abc";
-    AesUtils.decodeOkapiToken(token);
+    final String token = "abc";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AesUtils.decodeOkapiToken(token));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecodeOkapiTokenInvalidJson() {
-    String token = "abc.def";
-    AesUtils.decodeOkapiToken(token);
+    final String token = "abc.def";
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AesUtils.decodeOkapiToken(token));
   }
-
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-# variables are substituted from filters-[production|development].properties
-log4j.rootLogger=INFO, CONSOLE
-#log4j.rootLogger=DEBUG, CONSOLE
-
-# CONSOLE is set to be a ConsoleAppender using a PatternLayout.
-log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
-log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
-log4j.appender.CONSOLE.layout.ConversionPattern=%d{HH:mm:ss} %-5p %-20.20C{1} %m%n

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Appenders>
+    <Console name="STDOUT" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{HH:mm:ss} %-5p %-20.20C{1} %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.folio.aes" level="debug"/>
+    <Root level="info">
+      <AppenderRef ref="STDOUT"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
- Updated Vert.x to v3.9.0 and updated code where needed.
- Replaced the Vert.x logging framework with Log4j2, since Vert.x is deprecating their logging framework in v4.0.0 and making it internal only in a later version (>4.0.0).
- Updated to JUnit 5 and modified tests as needed.
- Updated test dependencies, like Mockito and REST-assured.
- Updated POM dependencies.
- Made transitive dependencies explicit.