### PR TITLE
MODAES-7: URL encode the CQL query

### DIFF
--- a/src/main/java/org/folio/aes/service/AesService.java
+++ b/src/main/java/org/folio/aes/service/AesService.java
@@ -55,7 +55,7 @@ public class AesService {
     String msg = data.encodePrettily();
     logger.trace(msg);
 
-    String okapiUrl = headers.get(OKAPI_URL) + CONFIG_ROUTING_QUREY;
+    String okapiUrl = headers.get(OKAPI_URL) + CONFIG_ROUTING_QUERY;
     String tenant = headers.get(OKAPI_TENANT);
 
     // Run it asynchronously since OKAPI does not care response

--- a/src/main/java/org/folio/aes/util/AesConstants.java
+++ b/src/main/java/org/folio/aes/util/AesConstants.java
@@ -1,5 +1,7 @@
 package org.folio.aes.util;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -18,8 +20,9 @@ public class AesConstants {
   // mod-config related
   public static final String CONFIG_CONFIGS = "configs";
   public static final String CONFIG_VALUE = "value";
-  public static final String CONFIG_ROUTING_QUREY = String
-    .format("/configurations/entries?query=(module=AES and configName=routing_rules)&limit=%d", Integer.MAX_VALUE);
+  public static final String CONFIG_QUERY_CQL = encode("(module=AES and configName=routing_rules)");
+  public static final String CONFIG_ROUTING_QUERY = String
+    .format("/configurations/entries?query=%s&limit=%d", CONFIG_QUERY_CQL, Integer.MAX_VALUE);
   public static final String CONFIG_ROUTING_CRITERIA = "criteria";
   public static final String CONFIG_ROUTING_TARGET = "target";
 
@@ -57,4 +60,13 @@ public class AesConstants {
     JsonPath.compile("$..username"),
     JsonPath.compile("$..requester"),
     JsonPath.compile("$..user")));
+
+  private static final String encode(String value) {
+    try {
+      return URLEncoder.encode(value, "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      // Should never happen with a compliant JVM
+      return value;
+    }
+  }
 }

--- a/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
+++ b/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.aes.test.Utils.nextFreePort;
 import static org.folio.aes.util.AesConstants.CONFIG_CONFIGS;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_CRITERIA;
+import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_QUERY;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_TARGET;
 import static org.folio.aes.util.AesConstants.CONFIG_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,7 +65,7 @@ public class RuleServiceConfigImplTest {
 
   @Test
   public void testGetConfig() throws Exception {
-    String okapiUrl = "http://localhost:" + port;
+    String okapiUrl = "http://localhost:" + port + CONFIG_ROUTING_QUERY;
     CompletableFuture<Collection<RoutingRule>> cf = ruleService.getRules(okapiUrl, tenant, token);
     Collection<RoutingRule> rules = cf.get();
     assertEquals(count, rules.size());


### PR DESCRIPTION
nginx does not like spaces in the query, probably anywhere in the URL as well, so we need to encode the CQL passed in the `query` query parameter. It is difficult to write a test for this, but all CQL should be encoded anyway, to be on the safe side. The rules test was updated to include the full path we use for configuration retrieval. When set, the test fails without encoding. Vert.x appears to close the connection before it gets to the response code. The test works fine with the CQL encoded and the full path the configuration specified.