### PR TITLE
MODAES-10: Add "requires" field to the aes interface

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -26,6 +26,12 @@
     }
   ],
   "provides": [],
+  "requires": [
+    {
+      "id": "configuration",
+      "version": "2.0"
+    }
+  ],
   "permissionSets": [],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",


### PR DESCRIPTION
Since we use the configuration interface, we need a requires section that indicates such. This has been added.