### PR TITLE
MODAES-11&12: reduce the number of warnings in the AES log

### DIFF
--- a/src/main/java/org/folio/aes/service/AesService.java
+++ b/src/main/java/org/folio/aes/service/AesService.java
@@ -126,7 +126,7 @@ public class AesService {
       try {
         bodyJson = bodyBuffer.toJson();
       } catch (Exception e) {
-        logger.warn("Failed to convert to JSON: {}", ctx::getBodyAsString);
+        logger.warn("Failed to convert to JSON: {}", bodyBuffer::toString);
         bodyJson = null;
       }
     }

--- a/src/main/java/org/folio/aes/util/AesConstants.java
+++ b/src/main/java/org/folio/aes/util/AesConstants.java
@@ -33,6 +33,8 @@ public class AesConstants {
   public static final String OKAPI_TOKEN_SUB = "sub";
   public static final String OKAPI_TOKEN_AUTH_MOD = "_AUTHZ_MODULE_";
   public static final String OKAPI_AES_FILTER_ID = "x-okapi-aes-filter-id";
+  public static final String OKAPI_HANDLER_RESULT = "x-okapi-handler-result";
+  public static final String CONTENT_TYPE = "content-type";
 
   // topics
   public static final String TENANT_NONE = "tenant_none";

--- a/src/main/java/org/folio/aes/util/AesUtils.java
+++ b/src/main/java/org/folio/aes/util/AesUtils.java
@@ -70,6 +70,16 @@ public class AesUtils {
     return jo;
   }
 
+  public static void maskPassword(Object o) {
+    if (o instanceof JsonObject) {
+      maskPassword((JsonObject) o);
+    } else {
+      for (Object child : (JsonArray) o) {
+        maskPassword(child);
+      }
+    }
+  }
+
   /**
    * Mask password.
    *
@@ -83,10 +93,22 @@ public class AesUtils {
     }
   }
 
-  public static boolean containsPII(String bodyString) {
+  public static boolean containsPII(Object o) {
+    if (o instanceof JsonObject) {
+      return containsPII((JsonObject) o);
+    } else {
+      for (Object child : (JsonArray) o) {
+        if (containsPII(child)) {
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
+  public static boolean containsPII(JsonObject body) {
     for (final JsonPath jp : PII_JSON_PATHS) {
-      final List<String> pathList = jp.read(bodyString,
-        PII_JSON_PATH_CONFIG);
+      final List<String> pathList = jp.read(body.toString(), PII_JSON_PATH_CONFIG);
       if (!pathList.isEmpty()) {
         return true;
       }

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -327,6 +327,117 @@ class AesServiceTest {
     verifyNoMoreInteractions(queueService);
   }
 
+  @Test
+  void testSendWith422Error(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
+      @Mock HttpServerResponse response) throws InterruptedException {
+    String topicA = "ta";
+    String topicB = "tb";
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_TENANT, "abc");
+    headers.add(OKAPI_TOKEN,
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    headers.add(OKAPI_HANDLER_RESULT, "422");
+    when(ctx.request()).thenReturn(request);
+    when(ctx.response()).thenReturn(response);
+    when(request.headers()).thenReturn(headers);
+    when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(ctx.getBody()).thenReturn(Buffer.buffer("{\"error\":\"test\"}"));
+    Collection<RoutingRule> rules = new ArrayList<>();
+    rules.add(new RoutingRule("$..*", topicA));
+    rules.add(new RoutingRule("$..*", topicB));
+    rules.add(new RoutingRule("$.xyz", topicB));
+    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
+    cf.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    aesService.prePostHandler(ctx);
+    long start = System.currentTimeMillis() + WAIT_TS;
+    await().until(() -> {
+      return System.currentTimeMillis() > start;
+    });
+    verify(ruleService, times(1)).getRules(any(), any(), any());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(queueService).send(eq(topicA), argument.capture());
+    checkMsg(argument.getValue());
+    verify(queueService).send(eq(topicB), argument.capture());
+    checkMsg(argument.getValue());
+    verifyNoMoreInteractions(queueService);
+  }
+
+  @Test
+  void testSendWithNoBody(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
+      @Mock HttpServerResponse response) throws InterruptedException {
+    String topicA = "ta";
+    String topicB = "tb";
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_TENANT, "abc");
+    headers.add(OKAPI_TOKEN,
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.request()).thenReturn(request);
+    when(ctx.response()).thenReturn(response);
+    when(request.headers()).thenReturn(headers);
+    when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(ctx.getBody()).thenReturn(Buffer.buffer());
+    Collection<RoutingRule> rules = new ArrayList<>();
+    rules.add(new RoutingRule("$..*", topicA));
+    rules.add(new RoutingRule("$..*", topicB));
+    rules.add(new RoutingRule("$.xyz", topicB));
+    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
+    cf.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    aesService.prePostHandler(ctx);
+    long start = System.currentTimeMillis() + WAIT_TS;
+    await().until(() -> {
+      return System.currentTimeMillis() > start;
+    });
+    verify(ruleService, times(1)).getRules(any(), any(), any());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(queueService).send(eq(topicA), argument.capture());
+    checkMsg(argument.getValue());
+    verify(queueService).send(eq(topicB), argument.capture());
+    checkMsg(argument.getValue());
+    verifyNoMoreInteractions(queueService);
+  }
+
+  @Test
+  void testSendWith100Status(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
+      @Mock HttpServerResponse response) throws InterruptedException {
+    String topicA = "ta";
+    String topicB = "tb";
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_TENANT, "abc");
+    headers.add(OKAPI_TOKEN,
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    headers.add(OKAPI_HANDLER_RESULT, "100");
+    when(ctx.request()).thenReturn(request);
+    when(ctx.response()).thenReturn(response);
+    when(request.headers()).thenReturn(headers);
+    when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(ctx.getBody()).thenReturn(Buffer.buffer());
+    Collection<RoutingRule> rules = new ArrayList<>();
+    rules.add(new RoutingRule("$..*", topicA));
+    rules.add(new RoutingRule("$..*", topicB));
+    rules.add(new RoutingRule("$.xyz", topicB));
+    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
+    cf.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    aesService.prePostHandler(ctx);
+    long start = System.currentTimeMillis() + WAIT_TS;
+    await().until(() -> {
+      return System.currentTimeMillis() > start;
+    });
+    verify(ruleService, times(1)).getRules(any(), any(), any());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(queueService).send(eq(topicA), argument.capture());
+    checkMsg(argument.getValue());
+    verify(queueService).send(eq(topicB), argument.capture());
+    checkMsg(argument.getValue());
+    verifyNoMoreInteractions(queueService);
+  }
+
   private static void checkMsg(String content) {
     JsonObject msg = new JsonObject(content);
     assertTrue(msg.containsKey(MSG_PATH));

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -8,6 +8,7 @@ import static org.folio.aes.util.AesConstants.MSG_PARAMS;
 import static org.folio.aes.util.AesConstants.MSG_PATH;
 import static org.folio.aes.util.AesConstants.MSG_PII;
 import static org.folio.aes.util.AesConstants.OKAPI_AES_FILTER_ID;
+import static org.folio.aes.util.AesConstants.OKAPI_HANDLER_RESULT;
 import static org.folio.aes.util.AesConstants.OKAPI_TENANT;
 import static org.folio.aes.util.AesConstants.OKAPI_TOKEN;
 import static org.folio.aes.util.AesConstants.TENANT_NONE;
@@ -33,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.JsonObject;
@@ -103,6 +105,7 @@ class AesServiceTest {
       @Mock HttpServerResponse response) throws InterruptedException {
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();
     headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -129,6 +132,7 @@ class AesServiceTest {
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();
     headers.add(OKAPI_TENANT, "abc");
     headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -154,11 +158,12 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-    when(ctx.getBodyAsString()).thenReturn("{}");
+    when(ctx.getBody()).thenReturn(Buffer.buffer("{}"));
     CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
     cf.complete(new ArrayList<>());
     when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
@@ -186,11 +191,12 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-    when(ctx.getBodyAsString()).thenReturn("{}");
+    when(ctx.getBody()).thenReturn(Buffer.buffer("{}"));
     Collection<RoutingRule> rules = new ArrayList<>();
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
@@ -221,11 +227,12 @@ class AesServiceTest {
     headers.add(OKAPI_TENANT, "abc");
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    headers.add(OKAPI_HANDLER_RESULT, "200");
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-    when(ctx.getBodyAsString()).thenReturn("");
+    when(ctx.getBody()).thenReturn(Buffer.buffer());
     Collection<RoutingRule> rules = new ArrayList<>();
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -438,6 +438,42 @@ class AesServiceTest {
     verifyNoMoreInteractions(queueService);
   }
 
+  @Test
+  void testSendWithNoRestultStatusCode(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
+      @Mock HttpServerResponse response) throws InterruptedException {
+    String topicA = "ta";
+    String topicB = "tb";
+    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+    headers.add("Content-Type", "application/json");
+    headers.add(OKAPI_TENANT, "abc");
+    headers.add(OKAPI_TOKEN,
+        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    when(ctx.request()).thenReturn(request);
+    when(ctx.response()).thenReturn(response);
+    when(request.headers()).thenReturn(headers);
+    when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
+    when(ctx.getBody()).thenReturn(Buffer.buffer("{}"));
+    Collection<RoutingRule> rules = new ArrayList<>();
+    rules.add(new RoutingRule("$..*", topicA));
+    rules.add(new RoutingRule("$..*", topicB));
+    rules.add(new RoutingRule("$.xyz", topicB));
+    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
+    cf.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    aesService.prePostHandler(ctx);
+    long start = System.currentTimeMillis() + WAIT_TS;
+    await().until(() -> {
+      return System.currentTimeMillis() > start;
+    });
+    verify(ruleService, times(1)).getRules(any(), any(), any());
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(queueService).send(eq(topicA), argument.capture());
+    checkMsg(argument.getValue());
+    verify(queueService).send(eq(topicB), argument.capture());
+    checkMsg(argument.getValue());
+    verifyNoMoreInteractions(queueService);
+  }
+
   private static void checkMsg(String content) {
     JsonObject msg = new JsonObject(content);
     assertTrue(msg.containsKey(MSG_PATH));

--- a/src/test/java/org/folio/aes/util/AesUtilsTest.java
+++ b/src/test/java/org/folio/aes/util/AesUtilsTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 class AesUtilsTest {
@@ -60,16 +61,42 @@ class AesUtilsTest {
     String login = "{\"username\":\"admin\",\"password\":\"secret\"}";
     String update = "{\"username\":\"admin\",\"userId\":\"123\",\"password\":\"before\",\"newPassword\":\"after\",\"id\":\"456\"}";
     for (String s : Arrays.asList(login, update)) {
-      JsonObject beforeMask = new JsonObject(s);
-      JsonObject afterMask = new JsonObject(s);
+      Object beforeMask = new JsonObject(s);
+      Object afterMask = new JsonObject(s);
       AesUtils.maskPassword(afterMask);
-      assertEquals(beforeMask.size(), afterMask.size());
-      afterMask.forEach(entry -> {
+      assertEquals(((JsonObject) beforeMask).size(), ((JsonObject) afterMask).size());
+      ((JsonObject) afterMask).forEach(entry -> {
         if (entry.getKey().contains("assword")) {
-          assertNotEquals(entry.getValue().toString(), beforeMask.getString(entry.getKey()));
+          assertNotEquals(entry.getValue().toString(),
+              ((JsonObject) beforeMask).getString(entry.getKey()));
           assertEquals(AesConstants.MSG_PW_MASK, entry.getValue().toString());
         } else {
-          assertEquals(entry.getValue().toString(), beforeMask.getString(entry.getKey()));
+          assertEquals(entry.getValue().toString(),
+              ((JsonObject) beforeMask).getString(entry.getKey()));
+        }
+      });
+    }
+  }
+
+  @Test
+  void testMaskPasswordWithArray() {
+    String login = "[{\"username\":\"admin\",\"password\":\"secret\"}]";
+    String update = "[{\"username\":\"admin\",\"userId\":\"123\",\"password\":\"before\",\"newPassword\":\"after\",\"id\":\"456\"}]";
+    for (String s : Arrays.asList(login, update)) {
+      Object beforeMask = new JsonArray(s);
+      Object afterMask = new JsonArray(s);
+      AesUtils.maskPassword(afterMask);
+      assertEquals(((JsonArray) beforeMask).size(), ((JsonArray) afterMask).size());
+      assertEquals(((JsonArray) beforeMask).getJsonObject(0).size(),
+          ((JsonArray) afterMask).getJsonObject(0).size());
+      ((JsonArray) afterMask).getJsonObject(0).forEach(entry -> {
+        if (entry.getKey().contains("assword")) {
+          assertNotEquals(entry.getValue().toString(),
+              ((JsonArray) beforeMask).getJsonObject(0).getString(entry.getKey()));
+          assertEquals(AesConstants.MSG_PW_MASK, entry.getValue().toString());
+        } else {
+          assertEquals(entry.getValue().toString(),
+              ((JsonArray) beforeMask).getJsonObject(0).getString(entry.getKey()));
         }
       });
     }
@@ -77,14 +104,28 @@ class AesUtilsTest {
 
   @Test
   void testContainsPII() {
-    final JsonObject user = new JsonObject("{\"username\":\"jhandey\",\"id\":\"7261ecaae3a74dc68b468e12a70b1aec\",\"active\":true,\"type\":\"patron\",\"patronGroup\":\"4bb563d9-3f9d-4e1e-8d1d-04e75666d68f\",\"meta\":{\"creation_date\":\"2016-11-05T0723\",\"last_login_date\":\"\"},\"personal\":{\"lastName\":\"Handey\",\"firstName\":\"Jack\",\"email\":\"jhandey@biglibrary.org\",\"phone\":\"2125551212\"}}");
+    final Object user = new JsonObject("{\"username\":\"jhandey\",\"id\":\"7261ecaae3a74dc68b468e12a70b1aec\",\"active\":true,\"type\":\"patron\",\"patronGroup\":\"4bb563d9-3f9d-4e1e-8d1d-04e75666d68f\",\"meta\":{\"creation_date\":\"2016-11-05T0723\",\"last_login_date\":\"\"},\"personal\":{\"lastName\":\"Handey\",\"firstName\":\"Jack\",\"email\":\"jhandey@biglibrary.org\",\"phone\":\"2125551212\"}}");
 
     assertTrue(AesUtils.containsPII(user));
   }
 
   @Test
   void testContainsPIINoPII() {
-    final JsonObject item = new JsonObject("{\"id\":\"0b96a642-5e7f-452d-9cae-9cee66c9a892\",\"title\":\"Uprooted\",\"callNumber\":\"D11.J54 A3 2011\",\"barcode\":\"645398607547\",\"status\":{\"name\":\"Available\"},\"materialType\":{\"id\":\"fcf3d3dc-b27f-4ce4-a530-542ea53cacb5\",\"name\":\"Book\"},\"permanentLoanType\":{\"id\":\"8e570d0d-931c-43d1-9ca1-221e693ea8d2\",\"name\":\"Can Circulate\"},\"temporaryLoanType\":{\"id\":\"74c25903-4019-4d8a-9360-5cb7761f44e5\",\"name\":\"Course Reserve\"},\"permanentLocation\":{\"id\":\"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\",\"name\":\"Main Library\"}}");
+    final Object item = new JsonObject("{\"id\":\"0b96a642-5e7f-452d-9cae-9cee66c9a892\",\"title\":\"Uprooted\",\"callNumber\":\"D11.J54 A3 2011\",\"barcode\":\"645398607547\",\"status\":{\"name\":\"Available\"},\"materialType\":{\"id\":\"fcf3d3dc-b27f-4ce4-a530-542ea53cacb5\",\"name\":\"Book\"},\"permanentLoanType\":{\"id\":\"8e570d0d-931c-43d1-9ca1-221e693ea8d2\",\"name\":\"Can Circulate\"},\"temporaryLoanType\":{\"id\":\"74c25903-4019-4d8a-9360-5cb7761f44e5\",\"name\":\"Course Reserve\"},\"permanentLocation\":{\"id\":\"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\",\"name\":\"Main Library\"}}");
+
+    assertFalse(AesUtils.containsPII(item));
+  }
+
+  @Test
+  void testContainsPIIWithJsonArray() {
+    final Object user = new JsonArray("[{\"username\":\"jhandey\",\"id\":\"7261ecaae3a74dc68b468e12a70b1aec\",\"active\":true,\"type\":\"patron\",\"patronGroup\":\"4bb563d9-3f9d-4e1e-8d1d-04e75666d68f\",\"meta\":{\"creation_date\":\"2016-11-05T0723\",\"last_login_date\":\"\"},\"personal\":{\"lastName\":\"Handey\",\"firstName\":\"Jack\",\"email\":\"jhandey@biglibrary.org\",\"phone\":\"2125551212\"}}]");
+
+    assertTrue(AesUtils.containsPII(user));
+  }
+
+  @Test
+  void testContainsPIINoPIIWithJsonArray() {
+    final Object item = new JsonArray("[{\"id\":\"0b96a642-5e7f-452d-9cae-9cee66c9a892\",\"title\":\"Uprooted\",\"callNumber\":\"D11.J54 A3 2011\",\"barcode\":\"645398607547\",\"status\":{\"name\":\"Available\"},\"materialType\":{\"id\":\"fcf3d3dc-b27f-4ce4-a530-542ea53cacb5\",\"name\":\"Book\"},\"permanentLoanType\":{\"id\":\"8e570d0d-931c-43d1-9ca1-221e693ea8d2\",\"name\":\"Can Circulate\"},\"temporaryLoanType\":{\"id\":\"74c25903-4019-4d8a-9360-5cb7761f44e5\",\"name\":\"Course Reserve\"},\"permanentLocation\":{\"id\":\"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\",\"name\":\"Main Library\"}}]");
 
     assertFalse(AesUtils.containsPII(item));
   }

--- a/src/test/java/org/folio/aes/util/AesUtilsTest.java
+++ b/src/test/java/org/folio/aes/util/AesUtilsTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -17,9 +16,10 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
 
-public class AesUtilsTest {
+class AesUtilsTest {
 
   private static final String jsonpathTestContent;
   static {
@@ -32,7 +32,7 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testCheckJsonPaths() {
+  void testCheckJsonPaths() {
     String goodJsonPath = "$.store.book[?(@.price < 10)]";
     String badJsonPath = "$.store.book[?(@.price > 100)]";
     Set<String> jsonPaths = new HashSet<>(Arrays.asList(goodJsonPath, badJsonPath));
@@ -42,7 +42,7 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testConvertMultiMapToJsonObject() {
+  void testConvertMultiMapToJsonObject() {
     MultiMap map = MultiMap.caseInsensitiveMultiMap();
     map.add("a", "1 a");
     map.add("a", "2 a");
@@ -56,7 +56,7 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testMaskPassword() {
+  void testMaskPassword() {
     String login = "{\"username\":\"admin\",\"password\":\"secret\"}";
     String update = "{\"username\":\"admin\",\"userId\":\"123\",\"password\":\"before\",\"newPassword\":\"after\",\"id\":\"456\"}";
     for (String s : Arrays.asList(login, update)) {
@@ -76,29 +76,28 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testContainsPII() {
-    String user = "{\"username\":\"jhandey\",\"id\":\"7261ecaae3a74dc68b468e12a70b1aec\",\"active\":true,\"type\":\"patron\",\"patronGroup\":\"4bb563d9-3f9d-4e1e-8d1d-04e75666d68f\",\"meta\":{\"creation_date\":\"2016-11-05T0723\",\"last_login_date\":\"\"},\"personal\":{\"lastName\":\"Handey\",\"firstName\":\"Jack\",\"email\":\"jhandey@biglibrary.org\",\"phone\":\"2125551212\"}}";
+  void testContainsPII() {
+    final JsonObject user = new JsonObject("{\"username\":\"jhandey\",\"id\":\"7261ecaae3a74dc68b468e12a70b1aec\",\"active\":true,\"type\":\"patron\",\"patronGroup\":\"4bb563d9-3f9d-4e1e-8d1d-04e75666d68f\",\"meta\":{\"creation_date\":\"2016-11-05T0723\",\"last_login_date\":\"\"},\"personal\":{\"lastName\":\"Handey\",\"firstName\":\"Jack\",\"email\":\"jhandey@biglibrary.org\",\"phone\":\"2125551212\"}}");
 
     assertTrue(AesUtils.containsPII(user));
   }
 
   @Test
-  public void testContainsPIINoPII() {
-    String item = "{\"id\":\"0b96a642-5e7f-452d-9cae-9cee66c9a892\",\"title\":\"Uprooted\",\"callNumber\":\"D11.J54 A3 2011\",\"barcode\":\"645398607547\",\"status\":{\"name\":\"Available\"},\"materialType\":{\"id\":\"fcf3d3dc-b27f-4ce4-a530-542ea53cacb5\",\"name\":\"Book\"},\"permanentLoanType\":{\"id\":\"8e570d0d-931c-43d1-9ca1-221e693ea8d2\",\"name\":\"Can Circulate\"},\"temporaryLoanType\":{\"id\":\"74c25903-4019-4d8a-9360-5cb7761f44e5\",\"name\":\"Course Reserve\"},\"permanentLocation\":{\"id\":\"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\",\"name\":\"Main Library\"}}";
+  void testContainsPIINoPII() {
+    final JsonObject item = new JsonObject("{\"id\":\"0b96a642-5e7f-452d-9cae-9cee66c9a892\",\"title\":\"Uprooted\",\"callNumber\":\"D11.J54 A3 2011\",\"barcode\":\"645398607547\",\"status\":{\"name\":\"Available\"},\"materialType\":{\"id\":\"fcf3d3dc-b27f-4ce4-a530-542ea53cacb5\",\"name\":\"Book\"},\"permanentLoanType\":{\"id\":\"8e570d0d-931c-43d1-9ca1-221e693ea8d2\",\"name\":\"Can Circulate\"},\"temporaryLoanType\":{\"id\":\"74c25903-4019-4d8a-9360-5cb7761f44e5\",\"name\":\"Course Reserve\"},\"permanentLocation\":{\"id\":\"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\",\"name\":\"Main Library\"}}");
 
     assertFalse(AesUtils.containsPII(item));
   }
 
   @Test
-  public void testContainsPIIUserList() throws Exception {
-    String users = new String(Files.readAllBytes(Paths.get("src/test/resources/data/users.json")),
-      StandardCharsets.UTF_8);
+  void testContainsPIIUserList() throws Exception {
+    final JsonObject users = new JsonObject(Buffer.buffer(Files.readAllBytes(Paths.get("src/test/resources/data/users.json"))));
 
     assertTrue(AesUtils.containsPII(users));
   }
 
   @Test
-  public void testDecodeOkapiToken() {
+  void testDecodeOkapiToken() {
     String token = "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkaWt1X3VzZXIiLCJ1c2VyX2lkIjoiYWJjIiwidGVuYW50IjoiZGlrdSJ9.eMu6_Gjjo6G6TeTS3y--GmQGTtWryJtKznpGUUwpa0rDDwY1xLBDTQoHv06_mXYs2GyPOoeERUM_G_BEvpMZcA";
     JsonObject jo = AesUtils.decodeOkapiToken(token);
     assertEquals("diku_user", jo.getValue("sub"));
@@ -107,7 +106,7 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testDecodeOkapiTokenInvalidTokenFomrat() {
+  void testDecodeOkapiTokenInvalidTokenFomrat() {
     final String token = "abc";
     assertThrows(
         IllegalArgumentException.class,
@@ -115,7 +114,7 @@ public class AesUtilsTest {
   }
 
   @Test
-  public void testDecodeOkapiTokenInvalidJson() {
+  void testDecodeOkapiTokenInvalidJson() {
     final String token = "abc.def";
     assertThrows(
         IllegalArgumentException.class,


### PR DESCRIPTION
Handle some common cases where data is received in text instead of JSON. If this happens, we skip the JSON parsing, since it will always fail and issue a warning. This should clean up the log a bit.

This also fixes MODAES-12 by handling JSON arrays.