### PR TITLE
MODAES-13: fix WebClient memory leak

### DIFF
--- a/src/main/java/org/folio/aes/service/AesService.java
+++ b/src/main/java/org/folio/aes/service/AesService.java
@@ -22,6 +22,7 @@ public class AesService {
   private QueueService queueService;
 
   public CompletableFuture<Void> stop() {
+    getRuleService().stop();
     return getQueueService().stop();
   }
 

--- a/src/main/java/org/folio/aes/service/RuleService.java
+++ b/src/main/java/org/folio/aes/service/RuleService.java
@@ -17,4 +17,5 @@ public interface RuleService {
    */
   CompletableFuture<Collection<RoutingRule>> getRules(String okapiUrl, String tenant, String token);
 
+  void stop();
 }


### PR DESCRIPTION
WebClients were being created whenever the configuration API was called, but these clients were not being closed. Since they were not closed, the underlying connection objects were not cleaned up. Eventually, the module will run out of memory.

We now create one WebClient when the verticle is started. This client is reused for all configuration API calls. The client is closed when the verticle is stopped.