### PR TITLE
MODAES-14: move from CompletableFuture to Vert.x Promise/Future

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <vertx.version>3.9.3</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
+    <log4j.version>2.13.3</log4j.version>
     <rest-assured.version>4.3.1</rest-assured.version>
     <jsonpath.version>2.4.0</jsonpath.version>
     <junit.version>5.7.0</junit.version>
@@ -66,7 +67,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -173,7 +174,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.5.13</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/aes/AesVerticle.java
+++ b/src/main/java/org/folio/aes/AesVerticle.java
@@ -1,6 +1,6 @@
 package org.folio.aes;
 
-import static org.folio.aes.util.AesConstants.*;
+import static org.folio.aes.util.AesConstants.MOD_NAME;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -65,19 +65,15 @@ public class AesVerticle extends AbstractVerticle {
   public void stop(Promise<Void> promise) {
     if (aesService != null) {
       aesService.stop()
-        .thenRun(promise::complete)
-        .handle((res, ex) -> {
+        .onComplete(promise)
+        .otherwise(ex -> {
           if (ex != null) {
             logger.warn(ex);
-            promise.fail(ex);
-            return ex;
           }
-          promise.complete();
-          return res;
+          return null;
         });
     } else {
       promise.complete();
     }
   }
-
 }

--- a/src/main/java/org/folio/aes/service/QueueService.java
+++ b/src/main/java/org/folio/aes/service/QueueService.java
@@ -1,6 +1,6 @@
 package org.folio.aes.service;
 
-import java.util.concurrent.CompletableFuture;
+import io.vertx.core.Future;
 
 public interface QueueService {
 
@@ -11,7 +11,7 @@ public interface QueueService {
    * @param msg
    * @return
    */
-  CompletableFuture<Void> send(String topic, String msg);
+  Future<Void> send(String topic, String msg);
 
   /**
    * Send message to topic of given queue.
@@ -21,13 +21,13 @@ public interface QueueService {
    * @param queueUrl
    * @return
    */
-  CompletableFuture<Void> send(String topic, String msg, String queueUrl);
+  Future<Void> send(String topic, String msg, String queueUrl);
 
   /**
    * Stop the queue service and clean up resources.
    *
    * @return
    */
-  CompletableFuture<Void> stop();
+  Future<Void> stop();
 
 }

--- a/src/main/java/org/folio/aes/service/QueueServiceLogImpl.java
+++ b/src/main/java/org/folio/aes/service/QueueServiceLogImpl.java
@@ -1,9 +1,9 @@
 package org.folio.aes.service;
 
-import java.util.concurrent.CompletableFuture;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import io.vertx.core.Future;
 
 /**
  * Just log the message.
@@ -14,24 +14,19 @@ public class QueueServiceLogImpl implements QueueService {
   private static Logger logger = LogManager.getLogger();
 
   @Override
-  public CompletableFuture<Void> send(String topic, String msg) {
-    CompletableFuture<Void> cf = new CompletableFuture<>();
+  public Future<Void> send(String topic, String msg) {
     logger.info("topic: {}", topic);
     logger.info(msg);
-    cf.complete(null);
-    return cf;
+    return Future.succeededFuture();
   }
 
   @Override
-  public CompletableFuture<Void> send(String topic, String msg, String queueUrl) {
+  public Future<Void> send(String topic, String msg, String queueUrl) {
     return send(topic, msg);
   }
 
   @Override
-  public CompletableFuture<Void> stop() {
-    CompletableFuture<Void> cf = new CompletableFuture<>();
-    cf.complete(null);
-    return cf;
+  public Future<Void> stop() {
+    return Future.succeededFuture();
   }
-
 }

--- a/src/main/java/org/folio/aes/service/RuleService.java
+++ b/src/main/java/org/folio/aes/service/RuleService.java
@@ -1,9 +1,10 @@
 package org.folio.aes.service;
 
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 import org.folio.aes.model.RoutingRule;
+
+import io.vertx.core.Future;
 
 public interface RuleService {
 
@@ -15,7 +16,7 @@ public interface RuleService {
    * @param token
    * @return
    */
-  CompletableFuture<Collection<RoutingRule>> getRules(String okapiUrl, String tenant, String token);
+  Future<Collection<RoutingRule>> getRules(String okapiUrl, String tenant, String token);
 
   void stop();
 }

--- a/src/test/java/org/folio/aes/CompressionTest.java
+++ b/src/test/java/org/folio/aes/CompressionTest.java
@@ -5,7 +5,6 @@ import static io.vertx.junit5.web.TestRequest.bodyResponse;
 import static io.vertx.junit5.web.TestRequest.requestHeader;
 import static io.vertx.junit5.web.TestRequest.statusCode;
 import static io.vertx.junit5.web.TestRequest.testRequest;
-import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.folio.aes.test.Utils.nextFreePort;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -25,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpMethod;
@@ -104,9 +104,9 @@ class CompressionTest {
   @DisplayName("Shutdown")
   void tearDown(Vertx vertx, TestInfo testInfo) {
     // The AES service is stopped when the verticle is stopped, so we need the AES service mock
-    // to return a CompletableFuture so that there won't be an NPE. We make it lenient since it
+    // to return a Future so that there won't be an NPE. We make it lenient since it
     // may not be called by the time the MockitoExtension checks for unused stubs.
-    lenient().when(aesService.stop()).thenReturn(completedFuture(null));
+    lenient().when(aesService.stop()).thenReturn(Future.succeededFuture());
 
     log.info("Finished: {}", testInfo.getDisplayName());
   }

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.CompletableFuture;
 
 import org.folio.aes.model.RoutingRule;
 import org.junit.jupiter.api.Test;
@@ -34,6 +33,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vertx.core.MultiMap;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
@@ -106,6 +107,7 @@ class AesServiceTest {
     MultiMap headers = MultiMap.caseInsensitiveMultiMap();
     headers.add("Content-Type", "application/json");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -133,13 +135,14 @@ class AesServiceTest {
     headers.add(OKAPI_TENANT, "abc");
     headers.add("Content-Type", "application/json");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.completeExceptionally(new RuntimeException("abc"));
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.fail(new RuntimeException("abc"));
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -159,14 +162,15 @@ class AesServiceTest {
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add("Content-Type", "application/json");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
     when(ctx.getBody()).thenReturn(Buffer.buffer("{}"));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(new ArrayList<>());
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(new ArrayList<>());
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -192,6 +196,7 @@ class AesServiceTest {
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add("Content-Type", "application/json");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -201,9 +206,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -228,6 +233,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -237,9 +243,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -264,6 +270,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "400");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -273,9 +280,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -301,6 +308,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -310,9 +318,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -338,6 +346,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "422");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -347,9 +356,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -375,6 +384,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "200");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -384,9 +394,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -412,6 +422,7 @@ class AesServiceTest {
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
     headers.add(OKAPI_HANDLER_RESULT, "100");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -421,9 +432,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {
@@ -448,6 +459,7 @@ class AesServiceTest {
     headers.add(OKAPI_TENANT, "abc");
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
+    when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);
     when(request.headers()).thenReturn(headers);
@@ -457,9 +469,9 @@ class AesServiceTest {
     rules.add(new RoutingRule("$..*", topicA));
     rules.add(new RoutingRule("$..*", topicB));
     rules.add(new RoutingRule("$.xyz", topicB));
-    CompletableFuture<Collection<RoutingRule>> cf = new CompletableFuture<>();
-    cf.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(cf);
+    Promise<Collection<RoutingRule>> promise = Promise.promise();
+    promise.complete(rules);
+    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
     await().until(() -> {

--- a/src/test/java/org/folio/aes/service/KafkaServiceTest.java
+++ b/src/test/java/org/folio/aes/service/KafkaServiceTest.java
@@ -16,21 +16,21 @@ import io.vertx.core.Vertx;
 import io.vertx.junit5.VertxExtension;
 
 @ExtendWith(VertxExtension.class)
-public class KafkaServiceTest {
+class KafkaServiceTest {
 
   private KafkaService KafkaService = new KafkaService();
 
   @Test
-  public void testCreateProducer(Vertx vertx) {
-    final KafkaException expectedException = assertThrows(
-        KafkaException.class,
-        () -> assertNotNull(KafkaService.createProducer(vertx, new Properties())));
+  void testCreateProducer(Vertx vertx) {
+    final Properties properties = new Properties();
+    final KafkaException expectedException =
+        assertThrows(KafkaException.class, () -> KafkaService.createProducer(vertx, properties));
 
     assertThat(expectedException.getCause(), isA(ConfigException.class));
   }
 
   @Test
-  public void testCreateProducerRecord() {
+  void testCreateProducerRecord() {
     assertNotNull(KafkaService.createProducerRecord("test", "test"));
   }
 }

--- a/src/test/java/org/folio/aes/service/QueueServiceLogImplTest.java
+++ b/src/test/java/org/folio/aes/service/QueueServiceLogImplTest.java
@@ -2,33 +2,43 @@ package org.folio.aes.service;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.concurrent.CompletableFuture;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class QueueServiceLogImplTest {
+import io.vertx.core.Future;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class QueueServiceLogImplTest {
 
   private QueueService qs = new QueueServiceLogImpl();
 
   @Test
-  public void testSendOne() throws Exception {
-    CompletableFuture<Void> cf = qs.send(null, null);
-    cf.get();
-    assertTrue(cf.isDone());
+  void testSendOne(VertxTestContext testContext) throws Exception {
+    Future<Void> f = qs.send(null, null);
+    f.onComplete(testContext.succeeding(v -> {
+      assertTrue(f.isComplete());
+      testContext.completeNow();
+    }));
   }
 
   @Test
-  public void testSendTwo() throws Exception {
-    CompletableFuture<Void> cf = qs.send(null, null, null);
-    cf.get();
-    assertTrue(cf.isDone());
+  void testSendTwo(VertxTestContext testContext) throws Exception {
+    Future<Void> f = qs.send(null, null, null);
+    f.onComplete(testContext.succeeding(v -> {
+      assertTrue(f.isComplete());
+      testContext.completeNow();
+    }));
   }
 
   @Test
-  public void testStop() throws Exception {
-    CompletableFuture<Void> cf = qs.stop();
-    cf.get();
-    assertTrue(cf.isDone());
+  void testStop(VertxTestContext testContext) throws Exception {
+    Future<Void> f = qs.stop();
+    f.onComplete(testContext.succeeding(v -> {
+      assertTrue(f.isComplete());
+      testContext.completeNow();
+    }));
   }
 
 }


### PR DESCRIPTION
Refactored the async code to use Promises/Futures instead of CompletableFutures. Everything should execute in a Vert.x context and threads controlled by Vert.x. Used a profiler to check threads/memory and things looked good after many executions.