### PR TITLE
MODAES-15 and MODAES-16: Reduce garbage and fix configuration spamming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <vertx.version>3.9.4</vertx.version>
-    <log4j.version>2.13.3</log4j.version>
-    <rest-assured.version>4.3.1</rest-assured.version>
+    <log4j.version>2.14.0</log4j.version>
+    <rest-assured.version>4.3.2</rest-assured.version>
     <jsonpath.version>2.4.0</jsonpath.version>
     <junit.version>5.7.0</junit.version>
   </properties>
@@ -97,6 +97,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>3.4.2</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
     </dependency>
@@ -168,7 +174,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.5.13</version>
+      <version>3.6.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -181,6 +187,11 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>4.0.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-jcl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>

--- a/src/main/java/org/folio/aes/model/RoutingRule.java
+++ b/src/main/java/org/folio/aes/model/RoutingRule.java
@@ -1,5 +1,7 @@
 package org.folio.aes.model;
 
+import java.util.Objects;
+
 public class RoutingRule {
 
   private String criteria;
@@ -31,4 +33,20 @@ public class RoutingRule {
     this.target = target;
   }
 
+  @Override
+  public int hashCode() {
+    return Objects.hash(criteria, target);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof RoutingRule)) {
+      return false;
+    }
+    RoutingRule other = (RoutingRule) obj;
+    return Objects.equals(criteria, other.criteria) && Objects.equals(target, other.target);
+  }
 }

--- a/src/main/java/org/folio/aes/model/RoutingRule.java
+++ b/src/main/java/org/folio/aes/model/RoutingRule.java
@@ -4,8 +4,8 @@ import java.util.Objects;
 
 public class RoutingRule {
 
-  private String criteria;
-  private String target;
+  private final String criteria;
+  private final String target;
 
   public RoutingRule(String criteria, String target) {
     this.criteria = criteria;
@@ -21,16 +21,8 @@ public class RoutingRule {
     return criteria;
   }
 
-  public void setCriteria(String criteria) {
-    this.criteria = criteria;
-  }
-
   public String getTarget() {
     return target;
-  }
-
-  public void setTarget(String target) {
-    this.target = target;
   }
 
   @Override

--- a/src/main/java/org/folio/aes/service/QueueServiceKafkaImpl.java
+++ b/src/main/java/org/folio/aes/service/QueueServiceKafkaImpl.java
@@ -116,23 +116,7 @@ public class QueueServiceKafkaImpl implements QueueService {
   private KafkaProducer<String, String> getOrCreateProducer(String kafkaUrl) {
     logger.debug("Get Kafka producer for {}", kafkaUrl);
 
-    final KafkaProducer<String, String> producer = producers.get(kafkaUrl);
-
-    if (producer != null) {
-      logger.debug("Return an existing producer {}", System.identityHashCode(producer));
-      return producer;
-    } else {
-      var newProducer = createProducer(kafkaUrl);
-      KafkaProducer<String, String> p = producers.putIfAbsent(kafkaUrl, newProducer);
-      // just in case that a duplicate is created due to competition
-      if (p != null) {
-        logger.warn("Close a producer duplicate {}", System.identityHashCode(newProducer));
-        newProducer.close();
-        return p;
-      } else {
-        return newProducer;
-      }
-    }
+    return producers.computeIfAbsent(kafkaUrl, this::createProducer);
   }
 
   private KafkaProducer<String, String> createProducer(String kafkaUrl) {

--- a/src/main/java/org/folio/aes/util/AesConstants.java
+++ b/src/main/java/org/folio/aes/util/AesConstants.java
@@ -1,6 +1,7 @@
 package org.folio.aes.util;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,7 +21,8 @@ public class AesConstants {
   // mod-config related
   public static final String CONFIG_CONFIGS = "configs";
   public static final String CONFIG_VALUE = "value";
-  public static final String CONFIG_QUERY_CQL = encode("(module=AES and configName=routing_rules)");
+  public static final String CONFIG_QUERY_CQL =
+      URLEncoder.encode("(module=AES and configName=routing_rules)", UTF_8);
   public static final String CONFIG_ROUTING_QUERY = String
     .format("/configurations/entries?query=%s&limit=%d", CONFIG_QUERY_CQL, Integer.MAX_VALUE);
   public static final String CONFIG_ROUTING_CRITERIA = "criteria";
@@ -62,13 +64,4 @@ public class AesConstants {
     JsonPath.compile("$..username"),
     JsonPath.compile("$..requester"),
     JsonPath.compile("$..user")));
-
-  private static final String encode(String value) {
-    try {
-      return URLEncoder.encode(value, "UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      // Should never happen with a compliant JVM
-      return value;
-    }
-  }
 }

--- a/src/main/java/org/folio/aes/util/AesUtils.java
+++ b/src/main/java/org/folio/aes/util/AesUtils.java
@@ -3,13 +3,17 @@ package org.folio.aes.util;
 import static org.folio.aes.util.AesConstants.*;
 
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.folio.aes.model.RoutingRule;
+
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ParseContext;
 import com.jayway.jsonpath.ReadContext;
 
 import io.vertx.core.MultiMap;
@@ -25,20 +29,21 @@ public class AesUtils {
   // adjust JsonPath configuration to simplify path checking
   private static final Configuration jpConfig = Configuration.defaultConfiguration()
     .addOptions(Option.SUPPRESS_EXCEPTIONS, Option.ALWAYS_RETURN_LIST);
+  private static final ParseContext parseContext = JsonPath.using(jpConfig);
 
   /**
-   * Check JsonPaths.
+   * Check routing rules.
    *
    * @param json
-   * @param jsonPaths
+   * @param routingRules
    */
-  public static Set<String> checkJsonPaths(String json, Set<String> jsonPaths) {
-    Set<String> goodOnes = new HashSet<>();
-    ReadContext ctx = JsonPath.using(jpConfig).parse(json);
-    jsonPaths.forEach(jsonPath -> {
-      List<?> list = ctx.read(jsonPath);
+  public static Set<RoutingRule> checkRoutingRules(String json, Collection<RoutingRule> routingRules) {
+    Set<RoutingRule> goodOnes = new HashSet<>();
+    ReadContext ctx = parseContext.parse(json);
+    routingRules.forEach(routingRule -> {
+      List<?> list = ctx.read(routingRule.getCriteria());
       if (!list.isEmpty()) {
-        goodOnes.add(jsonPath);
+        goodOnes.add(routingRule);
       }
     });
     return goodOnes;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Root level="${sys:loglevel:-info}">
+    <Root level="${sys:loglevel:-info}" includeLocation="true">
       <AppenderRef ref="STDOUT"/>
     </Root>
   </Loggers>

--- a/src/test/java/org/folio/aes/model/RoutingRuleTest.java
+++ b/src/test/java/org/folio/aes/model/RoutingRuleTest.java
@@ -23,6 +23,7 @@ class RoutingRuleTest {
     final RoutingRule ruleCopy = new RoutingRule("$.store.book[?(@.price < 10)]", "tenant1");
     final RoutingRule ruleWrongCriteria = new RoutingRule("bad", "tenant1");
     final RoutingRule ruleWrongTarget = new RoutingRule(".store.book[?(@.price < 10)]", "bad");
+    final RoutingRule ruleWrongBoth = new RoutingRule("badCriteria", "badTarget");
     final Object badType = "bad";
 
     assertAll("equals",
@@ -30,7 +31,8 @@ class RoutingRuleTest {
         () -> assertEquals(true, rule.equals(ruleCopy)), // identical
         () -> assertEquals(false, rule.equals(badType)), // wrong type
         () -> assertEquals(false, rule.equals(ruleWrongCriteria)), // wrong criteria
-        () -> assertEquals(false, rule.equals(ruleWrongTarget)) // wrong target
+        () -> assertEquals(false, rule.equals(ruleWrongTarget)), // wrong target
+        () -> assertEquals(false, rule.equals(ruleWrongBoth)) // wrong criteria and target
     );
   }
 }

--- a/src/test/java/org/folio/aes/model/RoutingRuleTest.java
+++ b/src/test/java/org/folio/aes/model/RoutingRuleTest.java
@@ -22,8 +22,7 @@ class RoutingRuleTest {
   void testRoutingRuleEquality() {
     final RoutingRule ruleCopy = new RoutingRule("$.store.book[?(@.price < 10)]", "tenant1");
     final RoutingRule ruleWrongCriteria = new RoutingRule("bad", "tenant1");
-    final RoutingRule ruleWrongTarget = new RoutingRule(".store.book[?(@.price < 10)]", "bad");
-    final RoutingRule ruleWrongBoth = new RoutingRule("badCriteria", "badTarget");
+    final RoutingRule ruleWrongTarget = new RoutingRule("$.store.book[?(@.price < 10)]", "bad");
     final Object badType = "bad";
 
     assertAll("equals",
@@ -31,8 +30,7 @@ class RoutingRuleTest {
         () -> assertEquals(true, rule.equals(ruleCopy)), // identical
         () -> assertEquals(false, rule.equals(badType)), // wrong type
         () -> assertEquals(false, rule.equals(ruleWrongCriteria)), // wrong criteria
-        () -> assertEquals(false, rule.equals(ruleWrongTarget)), // wrong target
-        () -> assertEquals(false, rule.equals(ruleWrongBoth)) // wrong criteria and target
+        () -> assertEquals(false, rule.equals(ruleWrongTarget)) // wrong target
     );
   }
 }

--- a/src/test/java/org/folio/aes/model/RoutingRuleTest.java
+++ b/src/test/java/org/folio/aes/model/RoutingRuleTest.java
@@ -1,0 +1,36 @@
+package org.folio.aes.model;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class RoutingRuleTest {
+  final RoutingRule rule = new RoutingRule("$.store.book[?(@.price < 10)]", "tenant1");
+
+  @Test
+  void testRoutingRule() {
+    assertAll("rule",
+        () -> assertEquals("$.store.book[?(@.price < 10)]", rule.getCriteria()),
+        () -> assertEquals("tenant1", rule.getTarget()),
+        () -> assertEquals("RoutingRule [criteria=$.store.book[?(@.price < 10)], target=tenant1]",
+            rule.toString())
+    );
+  }
+
+  @Test
+  void testRoutingRuleEquality() {
+    final RoutingRule ruleCopy = new RoutingRule("$.store.book[?(@.price < 10)]", "tenant1");
+    final RoutingRule ruleWrongCriteria = new RoutingRule("bad", "tenant1");
+    final RoutingRule ruleWrongTarget = new RoutingRule(".store.book[?(@.price < 10)]", "bad");
+    final Object badType = "bad";
+
+    assertAll("equals",
+        () -> assertEquals(true, rule.equals(rule)), // identity
+        () -> assertEquals(true, rule.equals(ruleCopy)), // identical
+        () -> assertEquals(false, rule.equals(badType)), // wrong type
+        () -> assertEquals(false, rule.equals(ruleWrongCriteria)), // wrong criteria
+        () -> assertEquals(false, rule.equals(ruleWrongTarget)) // wrong target
+    );
+  }
+}

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import org.folio.aes.model.RoutingRule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -373,8 +375,9 @@ class AesServiceTest {
     verifyNoMoreInteractions(queueService);
   }
 
-  @Test
-  void testSendWithNoBody(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
+  @ParameterizedTest
+  @ValueSource(strings = {"200", "100", "garbage"})
+  void testSendWithNoBodyAndVariousStatuses(String statusCode, @Mock RoutingContext ctx, @Mock HttpServerRequest request,
       @Mock HttpServerResponse response) throws InterruptedException {
     String topicA = "ta";
     String topicB = "tb";
@@ -383,45 +386,7 @@ class AesServiceTest {
     headers.add(OKAPI_TENANT, "abc");
     headers.add(OKAPI_TOKEN,
         "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
-    headers.add(OKAPI_HANDLER_RESULT, "200");
-    when(ctx.vertx()).thenReturn(Vertx.vertx());
-    when(ctx.request()).thenReturn(request);
-    when(ctx.response()).thenReturn(response);
-    when(request.headers()).thenReturn(headers);
-    when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
-    when(ctx.getBody()).thenReturn(Buffer.buffer());
-    Collection<RoutingRule> rules = new ArrayList<>();
-    rules.add(new RoutingRule("$..*", topicA));
-    rules.add(new RoutingRule("$..*", topicB));
-    rules.add(new RoutingRule("$.xyz", topicB));
-    Promise<Collection<RoutingRule>> promise = Promise.promise();
-    promise.complete(rules);
-    when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
-    aesService.prePostHandler(ctx);
-    long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
-    verify(ruleService, times(1)).getRules(any(), any(), any());
-    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
-    verify(queueService).send(eq(topicA), argument.capture());
-    checkMsg(argument.getValue());
-    verify(queueService).send(eq(topicB), argument.capture());
-    checkMsg(argument.getValue());
-    verifyNoMoreInteractions(queueService);
-  }
-
-  @Test
-  void testSendWith100Status(@Mock RoutingContext ctx, @Mock HttpServerRequest request,
-      @Mock HttpServerResponse response) throws InterruptedException {
-    String topicA = "ta";
-    String topicB = "tb";
-    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-    headers.add("Content-Type", "application/json");
-    headers.add(OKAPI_TENANT, "abc");
-    headers.add(OKAPI_TOKEN,
-        "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJhYmMifQ.GHKsHPMokpfAhXrkrmA-qxGEWsCreg2PwOTQUfc4tB8xqDufyR0MApWwwPODD52P86RYZYctrOvX6UBW8NOG5g");
-    headers.add(OKAPI_HANDLER_RESULT, "100");
+    headers.add(OKAPI_HANDLER_RESULT, statusCode);
     when(ctx.vertx()).thenReturn(Vertx.vertx());
     when(ctx.request()).thenReturn(request);
     when(ctx.response()).thenReturn(response);

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -141,7 +141,7 @@ class AesServiceTest {
     when(request.headers()).thenReturn(headers);
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
     Promise<Collection<RoutingRule>> promise = Promise.promise();
-    promise.fail(new RuntimeException("abc"));
+    promise.fail("abc");
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;

--- a/src/test/java/org/folio/aes/util/AesUtilsTest.java
+++ b/src/test/java/org/folio/aes/util/AesUtilsTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.folio.aes.model.RoutingRule;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.MultiMap;
@@ -33,13 +34,13 @@ class AesUtilsTest {
   }
 
   @Test
-  void testCheckJsonPaths() {
-    String goodJsonPath = "$.store.book[?(@.price < 10)]";
-    String badJsonPath = "$.store.book[?(@.price > 100)]";
-    Set<String> jsonPaths = new HashSet<>(Arrays.asList(goodJsonPath, badJsonPath));
-    Set<String> rs = AesUtils.checkJsonPaths(jsonpathTestContent, jsonPaths);
-    assertTrue(rs.contains(goodJsonPath));
-    assertFalse(rs.contains(badJsonPath));
+  void testCheckRoutingRules() {
+    RoutingRule goodRoutingRule = new RoutingRule("$.store.book[?(@.price < 10)]", "tenant1");
+    RoutingRule badRoutingRule = new RoutingRule("$.store.book[?(@.price > 100)]", "tenant2");
+    Set<RoutingRule> routingRules = new HashSet<>(Arrays.asList(goodRoutingRule, badRoutingRule));
+    Set<RoutingRule> rs = AesUtils.checkRoutingRules(jsonpathTestContent, routingRules);
+    assertTrue(rs.contains(goodRoutingRule));
+    assertFalse(rs.contains(badRoutingRule));
   }
 
   @Test

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -6,8 +6,8 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="org.folio.aes" level="debug"/>
-    <Root level="info">
+    <Logger name="org.folio.aes" level="debug" includeLocation="true"/>
+    <Root level="info" includeLocation="true">
       <AppenderRef ref="STDOUT"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
MODAES-15: Removed creation of objects that were either not used or were used temporarily, but could have been reused. Cleaned up some async workflows so that they are more concise. Refactored some code that can now take advantage of Java 11. Added config so that we can enable async logging via Log4j2 without having to rebuild the fat jar. Once deployed, async logging can be enabled by supplying`-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector`
at startup.

MODAES-16: instead of using a timeout check, which can lead to a state where there is nothing in the cache and many asynchronous requests fire configuration requests, we now use `computeIfAbsent` to retrieve the rules from the configuration interface and store the `Future` in the map. If the `Future` succeeds, we set a Vert.x timer that will remove the rules `Future` when the timer completes. If the `Future` fails, we remove the rules `Future` from the map so the next request will trigger a request. Since this is all done in a `ConcurrentHashMap`, the configuration request is only performed once per cache period, assuming success and constant traffic. When the `Future` is removed from the map all requests will get the `Future` that is stored in the map via the first request that finds the key to be absent in the map. When the `Future` completes successfully, all waiting requests will complete with the retrieved rules. Future requests will get the completed `Future` from the map. In this way, the AES service does not require code changes to use this fix since we are still returning a `Future<Collection<RoutingRule>>`.

Additionally:
* Made `RoutingRule` immutable and added explicit tests
* Increased code coverage by removing code. Refactored Kafka producer creation to use `computeIfAbsent` instead of `putIfAbsent`. This allows us to create the provider just in time and we no longer need to potentially close unused created providers due to contention.
* Updated dependency versions for Log4j2, rest-assured and mockito.