### PR TITLE
MODAES-18: Updated dependencies + code updates for new versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <vertx.version>3.9.4</vertx.version>
-    <log4j.version>2.14.0</log4j.version>
-    <rest-assured.version>4.3.2</rest-assured.version>
+    <vertx.version>4.0.3</vertx.version>
+    <log4j.version>2.14.1</log4j.version>
+    <rest-assured.version>4.3.3</rest-assured.version>
     <jsonpath.version>2.4.0</jsonpath.version>
-    <junit.version>5.7.0</junit.version>
+    <junit.version>5.7.1</junit.version>
   </properties>
 
   <repositories>
@@ -53,7 +53,6 @@
     <developerConnection>scm:git:git@github.com:folio-org/mod-aes.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-
 
   <dependencyManagement>
     <dependencies>
@@ -151,8 +150,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-junit5-web-client</artifactId>
+      <groupId>io.reactiverse</groupId>
+      <artifactId>reactiverse-junit5-web-client</artifactId>
+      <version>0.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -179,13 +179,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.6.0</version>
+      <version>3.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.6.0</version>
+      <version>3.9.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -287,17 +287,22 @@
                 <filter>
                   <artifact>*:*</artifact>
                   <excludes>
-                    <exclude>module-info.class</exclude>
+                     <exclude>module-info.class</exclude>
                     <exclude>META-INF/MANIFEST.MF</exclude>
-                    <exclude>META-INF/LICENSE</exclude>
                     <exclude>META-INF/DEPENDENCIES</exclude>
-                    <exclude>META-INF/NOTICE</exclude>
                   </excludes>
                 </filter>
               </filters>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                   <resource>META-INF/io.netty.versions.properties</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>false</addHeader>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <manifestEntries>
@@ -334,12 +339,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.2</version>
         <dependencies>
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.35</version>
+            <version>8.41.1</version>
           </dependency>
         </dependencies>
         <executions>

--- a/src/main/java/org/folio/aes/AesLauncher.java
+++ b/src/main/java/org/folio/aes/AesLauncher.java
@@ -4,7 +4,9 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 
-// Just for development
+/**
+ * Just for development.
+ */
 public class AesLauncher {
 
   static {
@@ -14,6 +16,7 @@ public class AesLauncher {
 
   /**
    * Development launcher.
+   *
    * @param args application args
    */
   public static void main(String[] args) {

--- a/src/main/java/org/folio/aes/AesVerticle.java
+++ b/src/main/java/org/folio/aes/AesVerticle.java
@@ -15,6 +15,9 @@ import org.folio.aes.service.QueueServiceKafkaImpl;
 import org.folio.aes.service.QueueServiceLogImpl;
 import org.folio.aes.service.RuleServiceConfigImpl;
 
+/**
+ * The AES main verticle.
+ */
 public class AesVerticle extends AbstractVerticle {
 
   private static final Logger logger = LogManager.getLogger();

--- a/src/main/java/org/folio/aes/model/RoutingRule.java
+++ b/src/main/java/org/folio/aes/model/RoutingRule.java
@@ -2,6 +2,9 @@ package org.folio.aes.model;
 
 import java.util.Objects;
 
+/**
+ * A routing rule is used to determine which messages will be routed via AES.
+ */
 public class RoutingRule {
 
   private final String criteria;

--- a/src/main/java/org/folio/aes/service/AesService.java
+++ b/src/main/java/org/folio/aes/service/AesService.java
@@ -32,6 +32,9 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.aes.model.RoutingRule;
 
+/**
+ * The AES service.
+ */
 public class AesService {
 
   private static Logger logger = LogManager.getLogger();
@@ -46,6 +49,7 @@ public class AesService {
 
   /**
    * Handle pre/post filter data from Okapi.
+   *
    * @param ctx the vertx routing context
    */
   public void prePostHandler(RoutingContext ctx) {
@@ -106,7 +110,7 @@ public class AesService {
 
   private JsonObject collectData(RoutingContext ctx) {
     final JsonObject data = new JsonObject();
-    data.put(MSG_PATH, ctx.normalisedPath());
+    data.put(MSG_PATH, ctx.normalizedPath());
     data.put(MSG_HEADERS, convertMultiMapToJsonObject(ctx.request().headers()));
     data.put(MSG_PARAMS, convertMultiMapToJsonObject(ctx.request().params()));
     final Buffer bodyBuffer = ctx.getBody() == null ? Buffer.buffer() : ctx.getBody();

--- a/src/main/java/org/folio/aes/service/KafkaService.java
+++ b/src/main/java/org/folio/aes/service/KafkaService.java
@@ -7,6 +7,9 @@ import java.util.Properties;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * The Kafka service is used to send routed messages to Kafka.
+ */
 public class KafkaService {
 
   private static Logger logger = LogManager.getLogger();

--- a/src/main/java/org/folio/aes/service/QueueService.java
+++ b/src/main/java/org/folio/aes/service/QueueService.java
@@ -2,6 +2,9 @@ package org.folio.aes.service;
 
 import io.vertx.core.Future;
 
+/**
+ * The service for sending routed messages to a queue.
+ */
 public interface QueueService {
 
   /**

--- a/src/main/java/org/folio/aes/service/RuleService.java
+++ b/src/main/java/org/folio/aes/service/RuleService.java
@@ -4,6 +4,9 @@ import io.vertx.core.Future;
 import java.util.Collection;
 import org.folio.aes.model.RoutingRule;
 
+/**
+ * Interface for the rule service.
+ */
 public interface RuleService {
   Future<Collection<RoutingRule>> getRules(String okapiUrl, String tenant, String token);
 

--- a/src/main/java/org/folio/aes/util/AesConstants.java
+++ b/src/main/java/org/folio/aes/util/AesConstants.java
@@ -8,6 +8,9 @@ import com.jayway.jsonpath.Option;
 import java.net.URLEncoder;
 import java.util.List;
 
+/**
+ * AES constants.
+ */
 public class AesConstants {
 
   private AesConstants() {

--- a/src/main/java/org/folio/aes/util/AesUtils.java
+++ b/src/main/java/org/folio/aes/util/AesUtils.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.Set;
 import org.folio.aes.model.RoutingRule;
 
-
+/**
+ * AES utils.
+ */
 public class AesUtils {
 
   private AesUtils() {

--- a/src/test/java/org/folio/aes/AesVerticleTest.java
+++ b/src/test/java/org/folio/aes/AesVerticleTest.java
@@ -39,7 +39,7 @@ class AesVerticleTest {
     final DeploymentOptions opts = new DeploymentOptions();
     opts.setConfig(config);
 
-    vertx.deployVerticle(new AesVerticle(), opts, testContext.completing());
+    vertx.deployVerticle(new AesVerticle(), opts, testContext.succeedingThenComplete());
 
     RestAssured.port = port;
     RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();

--- a/src/test/java/org/folio/aes/CompressionTest.java
+++ b/src/test/java/org/folio/aes/CompressionTest.java
@@ -1,15 +1,16 @@
 package org.folio.aes;
 
+import static io.reactiverse.junit5.web.TestRequest.bodyResponse;
+import static io.reactiverse.junit5.web.TestRequest.requestHeader;
+import static io.reactiverse.junit5.web.TestRequest.statusCode;
+import static io.reactiverse.junit5.web.TestRequest.testRequest;
 import static io.vertx.core.buffer.Buffer.buffer;
-import static io.vertx.junit5.web.TestRequest.bodyResponse;
-import static io.vertx.junit5.web.TestRequest.requestHeader;
-import static io.vertx.junit5.web.TestRequest.statusCode;
-import static io.vertx.junit5.web.TestRequest.testRequest;
 import static org.folio.aes.test.Utils.nextFreePort;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 
+import io.reactiverse.junit5.web.WebClientOptionsInject;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -21,8 +22,6 @@ import io.vertx.ext.web.client.WebClient;
 import io.vertx.ext.web.client.WebClientOptions;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
-import io.vertx.junit5.web.VertxWebClientExtension;
-import io.vertx.junit5.web.WebClientOptionsInject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.aes.service.AesService;
@@ -44,12 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @author mreno
  *
  */
-// We'll need to fix the deprecation use in this test when we move to Vert.x 4.0. These WebClient
-// classes are being moved to the reactiverse:
-//   * https://github.com/reactiverse/reactiverse-junit5-extensions/
-// There is nothing we can do about it now since the new code is not released yet.
-@SuppressWarnings("deprecation")
-@ExtendWith({VertxExtension.class, VertxWebClientExtension.class, MockitoExtension.class})
+@ExtendWith({VertxExtension.class, MockitoExtension.class})
 class CompressionTest {
   private static Logger log = LogManager.getLogger();
 
@@ -97,7 +91,7 @@ class CompressionTest {
     final DeploymentOptions opts = new DeploymentOptions();
     opts.setConfig(config);
 
-    vertx.deployVerticle(aesVerticle, opts, testContext.completing());
+    vertx.deployVerticle(aesVerticle, opts, testContext.succeedingThenComplete());
 
     log.info("Verticle deployment complete");
   }

--- a/src/test/java/org/folio/aes/service/AesServiceTest.java
+++ b/src/test/java/org/folio/aes/service/AesServiceTest.java
@@ -115,9 +115,7 @@ class AesServiceTest {
     when(request.params()).thenReturn(MultiMap.caseInsensitiveMultiMap());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verifyNoMoreInteractions(ruleService);
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService, times(1)).send(eq(TENANT_NONE), argument.capture());
@@ -146,9 +144,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     verifyNoMoreInteractions(queueService);
   }
@@ -174,9 +170,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(defaultTopic), argument.capture());
@@ -212,9 +206,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -249,9 +241,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -286,9 +276,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -324,9 +312,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -362,9 +348,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -403,9 +387,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());
@@ -440,9 +422,7 @@ class AesServiceTest {
     when(ruleService.getRules(any(), any(), any())).thenReturn(promise.future());
     aesService.prePostHandler(ctx);
     long start = System.currentTimeMillis() + WAIT_TS;
-    await().until(() -> {
-      return System.currentTimeMillis() > start;
-    });
+    await().until(() -> System.currentTimeMillis() > start);
     verify(ruleService, times(1)).getRules(any(), any(), any());
     ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
     verify(queueService).send(eq(topicA), argument.capture());

--- a/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
+++ b/src/test/java/org/folio/aes/service/RuleServiceConfigImplTest.java
@@ -1,6 +1,5 @@
 package org.folio.aes.service;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.aes.test.Utils.nextFreePort;
 import static org.folio.aes.util.AesConstants.CONFIG_CONFIGS;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_CRITERIA;
@@ -8,7 +7,6 @@ import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_QUERY;
 import static org.folio.aes.util.AesConstants.CONFIG_ROUTING_TARGET;
 import static org.folio.aes.util.AesConstants.CONFIG_VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.Future;
 import io.vertx.core.Vertx;
@@ -45,19 +43,13 @@ class RuleServiceConfigImplTest {
       } else {
         r.response().setStatusCode(404).end();
       }
-    }).listen(port, context.completing());
-
-    assertTrue(context.awaitCompletion(5, SECONDS));
-
-    if (context.failed()) {
-      throw context.causeOfFailure();
-    }
+    }).listen(port, context.succeedingThenComplete());
   }
 
   @AfterAll
   @DisplayName("Shut down HTTP server")
   public static void tearDownOnce(Vertx vertx, VertxTestContext context) {
-    vertx.close(context.completing());
+    vertx.close(context.succeedingThenComplete());
   }
 
   @BeforeEach

--- a/src/test/java/org/folio/aes/test/Utils.java
+++ b/src/test/java/org/folio/aes/test/Utils.java
@@ -4,6 +4,9 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.ThreadLocalRandom;
 
+/**
+ * Test utils.
+ */
 public final class Utils {
   private Utils() {
     super();


### PR DESCRIPTION
 Updated versions for [MODAES-18](https://issues.folio.org/browse/MODAES-18):
- Vert.x 4.0.3
- log4j 2.14.1
- junit 5.7.1
- mockito 3.9.0
- checkstyle 8.41.1

Replaced:
- vertx-junit5-web-client with reactiverse-junit5-web-client 0.3.0

Vert.x 4 required a change from removed `RoutingContext.normalisedPath()` to `RoutingContext.normalizedPath()`. Also, for testing, `completing()` was deprecated and replaced with `succeedingThenComplete()`. Some minor changes were made to use the reactiverse version of the junit5 web client. Cleaned up some tests.

Latest checkstyle requires class-level javadoc, so added a comment to each class that was missing one. It also requires a new line between descriptions and parameters in method javadoc.