### PR TITLE
FOLIO-3231 Remove old API lint and doc config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,6 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  publishAPI = 'no'
-  runLintRamlCop = 'no'
   buildNode = 'jenkins-agent-java11'
 
   doDocker = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-aes
 
-Copyright (C) 2017-2020 The Open Library Foundation
+Copyright (C) 2017-2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The settings were 'false' so not being used.
If needed in the future, then use api-lint and api-doc.

The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/
